### PR TITLE
New filters on install/upgrade bug

### DIFF
--- a/server-side/installation.ts
+++ b/server-side/installation.ts
@@ -1,19 +1,8 @@
-
-/*
-The return object format MUST contain the field 'success':
-{success:true}
-
-If the result of your code is 'false' then return:
-{success:false, errorMessage:{the reason why it is false}}
-The error Message is important! it will be written in the audit log and help the user to understand what happen
-*/
-
 import { Client, Request } from '@pepperi-addons/debug-server';
 import { BasicFilterRuleData } from '../shared/types';
 import { FilterObjectService } from './services/filter-object.service';
 import { FilterRuleService } from './services/filter-rule.service';
 import { RelationsService } from './services/relations.service';
-import semver from 'semver';
 
 export async function install(client: Client, request: Request): Promise<any> {
     try {
@@ -28,8 +17,10 @@ export async function install(client: Client, request: Request): Promise<any> {
         // upsert default Filters and Profile-filters
         const basicFilterRuleData: BasicFilterRuleData[] = await filterObjectService.upsertBasicFilterObjects();
         await filterRuleService.upsertBasicFilterRules(basicFilterRuleData);
-    } catch (err) {
-        throw new Error(`installation failed. error - ${err}`);
+
+    } catch (error) {
+        console.error(`installation failed, error: ${(error as Error).message}`);
+        throw error;
     }
 
     return { success: true, resultObject: {} };
@@ -57,16 +48,13 @@ export async function upgrade(client: Client, request: Request): Promise<any> {
         await filterRuleService.upsertBasicFilterRules(basicFilterRuleData);
         
         return { success: true, resultObject: {} }
-
     }
-    catch (ex) {
-        console.error(`upgrade failed. error - ${ex}`);
-        throw ex;
+    catch (error) {
+        console.error(`upgrade failed. error - ${(error as Error).message}`);
+        throw error;
     }
 }
 
 export async function downgrade(client: Client, request: Request): Promise<any> {
     return { success: true, resultObject: {} }
 }
-
-

--- a/server-side/services/basic-table.service.ts
+++ b/server-side/services/basic-table.service.ts
@@ -110,11 +110,11 @@ export abstract class BasicTableService<T extends AddonData>{
 
     // validate schema
     validateSchema(addonData: T): void {
-        const v = new Validator();
-        const result = v.validate(addonData, this.jsonSchemaToValidate);
+        const validator = new Validator();
+        const result = validator.validate(addonData, this.jsonSchemaToValidate);
+        
         if (!result.valid) {
             throw new Error(`Scheme validation failed for ${this.schemaName} object: ${JSON.stringify(addonData)}\n${result.errors}`);
-
         }
     }
 
@@ -138,9 +138,9 @@ export abstract class BasicTableService<T extends AddonData>{
         try {
             return await this.postData(addonData);
         }
-        catch (ex) {
-            console.error(`Failed to upsert data to ${this.schemaName} table with error: ${ex}`);
-            throw ex;
+        catch (error) {
+            console.error(`Failed to upsert data to ${this.schemaName} table with error: ${(error as Error).message}`);
+            throw error;
         }
     }
 

--- a/server-side/services/duplicate-filters-bug-fix.service.ts
+++ b/server-side/services/duplicate-filters-bug-fix.service.ts
@@ -1,0 +1,59 @@
+import { Promise } from "bluebird";
+import { Client } from "@pepperi-addons/debug-server/dist";
+import { FilterRuleService } from "./filter-rule.service";
+import { FilterRule } from "../../shared/types";
+
+/**
+ * This class was created to handle bug DI-25619 which caused filters to be duplicated.
+ * 
+ * The duplication is now blocked in {@link FilterObjectService}, but because non 'Sync' filter-rules can
+ * have multiple mappings to the same resource (by design), there is no guard against duplicating those filter-rules,
+ * which causes them to point to the 'extra' filters.
+ * 
+ * 'Sync' filter-rules DOES have validation against duplication ({@link FilterRuleService.validateProfileFilterCombination})
+ * which grantees that there will be no duplication and that they will 
+ * point to the correct filter. 
+ */
+export class DuplicateFiltersBugFixService {
+
+    private filterRuleService: FilterRuleService;
+
+    constructor(client: Client) {
+        this.filterRuleService = new FilterRuleService(client);
+    }
+
+    /**
+     * Before deleting the filters we need to make sure no filter-rule is pointing to them,
+     * and if there is, we need to update the filter-rule to point to the oldest filter.
+     * @param filtersKeysToDelete The keys of the filters that are to be deleted.
+     * @param filterKeyToUse The key of the filter that is not deleted.
+     */
+    public async fixFilterRules(filtersKeysToDelete: string[], filterKeyToUse: string): Promise<void> {
+        // Get all filter rules that are not 'Sync'
+        const nonSyncFilterRules: FilterRule[] = await this.filterRuleService.get({
+            where: "PermissionSet!='Sync'"
+        });
+
+        // Find the filter rules that point to one of the filters that are to be deleted
+        // and update them to point to the filter that is not deleted.
+        const rulesPointingToFilter = nonSyncFilterRules.filter((filterRule) => filtersKeysToDelete.includes(filterRule.Filter));
+        rulesPointingToFilter.forEach((filterRule) => { filterRule.Filter = filterKeyToUse });
+
+        if (rulesPointingToFilter.length > 1) {
+            console.warn(`DuplicateFiltersBugFixService: found ${rulesPointingToFilter.length} filter rules pointing to the filters that are to be deleted, trying to fix..`);
+        }
+
+        // Update the filter rules.
+        try {
+            const MAX_PARALLEL = 1;
+
+            await Promise.map(rulesPointingToFilter, async (filterRule: FilterRule) => {
+                await this.filterRuleService.upsert(filterRule);
+            }, { concurrency: MAX_PARALLEL });
+        }
+        catch (error) {
+            console.error(`BugService: error while fixing filter rules: ${(error as Error).message}`);
+            throw error;
+        }
+    }
+}

--- a/server-side/services/filter-object.service.ts
+++ b/server-side/services/filter-object.service.ts
@@ -4,7 +4,6 @@ import { filterObjectJsonschema, filterObjectSchema, filterObjectSchemaName } fr
 import { BasicFilterRuleData, FilterObject } from "../../shared/types";
 import { BasicTableService } from "./basic-table.service";
 
-
 export class FilterObjectService extends BasicTableService<FilterObject>{
     schemaName: string;
     schema: AddonDataScheme;
@@ -140,12 +139,15 @@ export class FilterObjectService extends BasicTableService<FilterObject>{
 
     async upsertBasicFilterObjects(): Promise<BasicFilterRuleData[]> {
         try {
+            const allFilterObjects = await this.get();
+
             const currentUserFilterObject: FilterObject = {
                 Name: 'Current user',
                 Resource: 'users',
                 Field: 'Key'
             };
 
+            await this.getSystemFilterObjectKey(allFilterObjects, currentUserFilterObject);
             const usersResult = await this.upsert(currentUserFilterObject, true);
 
             const currentUserResourceAndKey = {
@@ -161,6 +163,7 @@ export class FilterObjectService extends BasicTableService<FilterObject>{
                 PreviousField: 'User'
             };
 
+            await this.getSystemFilterObjectKey(allFilterObjects, assignedAccountsFilterObject);
             const accountUsersResult = await this.upsert(assignedAccountsFilterObject, true);
 
             const assignedAccountsResourceAndKey = {
@@ -176,6 +179,7 @@ export class FilterObjectService extends BasicTableService<FilterObject>{
                 PreviousField: 'Key'
             };
 
+            await this.getSystemFilterObjectKey(allFilterObjects, profileFilterObject);
             const profileResult = await this.upsert(profileFilterObject, true);
 
             const profileResourceAndKey = {
@@ -185,10 +189,48 @@ export class FilterObjectService extends BasicTableService<FilterObject>{
 
             return [currentUserResourceAndKey, assignedAccountsResourceAndKey, profileResourceAndKey];
         }
-        catch (ex) {
-            console.error(`upsertBasicFilterObjects failed: ${ex}`);
-            throw ex;
+        catch (error) {
+            console.error(`upsertBasicFilterObjects failed: ${(error as Error).message})}`);
+            throw error;
         }
+    }
 
+    /**
+     * Searches for a system filter object with the same properties as the given filter object.
+     * If found, update the given filter object with the system filter object's key and delete all the newer duplicate system filter objects.
+     * @param currentFilterObject the filter object to search for.
+     */
+    private async getSystemFilterObjectKey(allFilterObjects: FilterObject[], currentFilterObject: FilterObject): Promise<void> {
+
+        // Find all filter objects that have the same properties as the given filter object,
+        // there could be more than one if Febula was upgraded/installed multiple times in the past (DI-25619).
+        const systemFilterObjects = allFilterObjects.filter((filterObject) => {
+            return filterObject.AddonUUID !== undefined &&
+                currentFilterObject.Name === filterObject.Name &&
+                currentFilterObject.Resource === filterObject.Resource &&
+                currentFilterObject.Field === filterObject.Field &&
+                (currentFilterObject.PreviousField === undefined || currentFilterObject.PreviousField === filterObject.PreviousField);
+        });
+
+        // If a system filter object was found, update the given filter object with the system filter object's key,
+        // log and delete all the other system filter objects.
+        if (systemFilterObjects.length > 0) {
+
+            if (systemFilterObjects.length > 1) {
+                console.warn(`getSystemFilterObject: found more than one (${systemFilterObjects.length}) system filter ('${currentFilterObject.Name}')`);
+            }
+
+            // Sort the system filter objects by creation time, so that the oldest one will be the first in the array.
+            // This is done so that we can delete all the newer system filter objects and keep the oldest one.
+            systemFilterObjects.sort((filterObjectA, filterObjectB) => {
+                const creationTimeA = new Date(filterObjectA.CreationDateTime!);
+                const creationTimeB = new Date(filterObjectB.CreationDateTime!);
+                return creationTimeA.getTime() - creationTimeB.getTime();
+            });
+            currentFilterObject.Key = systemFilterObjects[0].Key;
+
+            const filtersToDelete = systemFilterObjects.slice(1).map((filterObject) => filterObject.Key!);
+            await this.delete(filtersToDelete);
+        }
     }
 }

--- a/server-side/services/filter-rule.service.ts
+++ b/server-side/services/filter-rule.service.ts
@@ -5,7 +5,6 @@ import { BasicFilterRuleData, FilterObject, FilterRule } from "../../shared/type
 import { BasicTableService } from "./basic-table.service";
 import { FilterObjectService } from "./filter-object.service";
 import { Promise } from "bluebird";
-import { v4 as uuid } from "uuid";
 
 export class FilterRuleService extends BasicTableService<FilterRule>{
     schemaName: string;
@@ -191,5 +190,4 @@ export class FilterRuleService extends BasicTableService<FilterRule>{
             throw ex;
         }
     }
-
 }


### PR DESCRIPTION
Before creating new basic filter object search if one already exist.
If so - use it's key and delete the newest duplicates.

And some syntax changes because it hurts sometimes.